### PR TITLE
BUG: Exception happens if all registration settings are disabled.

### DIFF
--- a/sitkibex/registration.py
+++ b/sitkibex/registration.py
@@ -328,6 +328,9 @@ def registration(fixed_image: sitk.Image,
     :return: A SimpleITK transform mapping points from the fixed image to the moving. This may be a CompositeTransform.
 
     """
+    #Identity transform will be returned if all registration steps are disabled by
+    #the calling function.
+    result = sitk.Transform()
 
     initial_translation_3d = True
 

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -48,6 +48,17 @@ class TestReg(TestCase):
         fail_msg = "The distance between {0} and {1} exceeded tolerance".format(pt1, pt2)
         self.assertLess(distance, tolerance, msg=fail_msg)
 
+    def test_reg0(self):
+        pts = [[256,256,8]]
+        #all registration options set to False, so no registration is
+        #performed, returning the identity transformation.
+        tx = registration(sitk.Image([32,32], sitk.sitkUInt8),
+                          sitk.Image([32,32], sitk.sitkUInt8),
+                          do_fft_initialization=False,
+                          do_affine2d=False,
+                          do_affine3d=False)
+        self.check_near(pts[0], tx.TransformPoint(pts[0]))
+
     def test_reg1(self):
         fixed_pts = [[256, 256, 8],
                      [64, 64, 7]]


### PR DESCRIPTION
If all the registration options are set to false the "result" variable
didn't exist. Now it exists with identity transform.