### PR TITLE
Add separate GH Action to publish to PyPI and GH releases.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish
+
+
+jobs:
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    name: Upload release to Github Releases and PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: publish
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Build package
+      run: |
+        python -m pip install twine build
+        python -m build --wheel --sdist
+        python -m twine check dist/*
+        ls -la dist
+    - name: Create Release and Upload
+      id: create_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create ${{ github.ref_name }} --repo ${{ github.repository }} --verify-tag --generate-notes --title "Release ${{ github.ref_name }}"
+        gh release upload ${{ github.ref_name }} --repo ${{ github.repository }} dist/*
+
+
+    - name: PyPI Publish package
+      # hash for release/v1.8
+      uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/trufflehog3.yml
+++ b/trufflehog3.yml
@@ -7,6 +7,10 @@ exclude: # exclude matching issues
      pattern: \{GITHUB_TOKEN\}@github.com
      paths:
        - .github/workflows/main.yml
+   - message: "Workflow strings"
+     pattern: pypa/gh-action-pypi-publish@
+     paths:
+       - .github/workflows/publish.yml
    - message: Build Directories
      paths:
        - /docs/_build/**


### PR DESCRIPTION
Uses the "publish" environment to control access.